### PR TITLE
feat: add ENVECTOR_LICENSE_TOKEN for es2c

### DIFF
--- a/docker-compose/docker-compose.envector.yml
+++ b/docker-compose/docker-compose.envector.yml
@@ -64,6 +64,7 @@ services:
       ES2_THREAD_POOL_SCALE: "${ES2_THREAD_POOL_SCALE:-4}"
       ES2C_NUM_SEARCH_HANDLER: "${ES2C_NUM_SEARCH_HANDLER:-10}"
       ES2_LICENSE_TOKEN: "${ES2_LICENSE_TOKEN:-/es2/license/token.jwt}"
+      ENVECTOR_LICENSE_TOKEN: "/es2/license/token.jwt"
     # License file mount. Place your license token.jwt file in the same directory as this docker-compose file.
     volumes:
       - ./token.jwt:/es2/license/token.jwt


### PR DESCRIPTION
## Summary
- Add ENVECTOR_LICENSE_TOKEN environment variable for es2c license verification
- Enables license token mounting in Docker Compose setup

## Test plan
- [x] es2c container starts with license token mounted
- [x] License verification works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)