### PR TITLE
update 1.4.6

### DIFF
--- a/kubernetes-manifests/helm/Chart.yaml
+++ b/kubernetes-manifests/helm/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: envector-chart
 description: A Helm chart for the enVector microservices application
 type: application
-version: 1.4.3
-appVersion: "1.4.3"
+version: 1.4.6
+appVersion: "1.4.6"


### PR DESCRIPTION
Bump Helm chart to enVector 1.4.6.

- `kubernetes-manifests/helm/Chart.yaml`: `version` / `appVersion` 1.4.3 → 1.4.6

Version-only bump, matching the prior `update 1.4.3` (#19) PR. Content drift in `deployment/` (TEE/KMS/audit) is not synced in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)